### PR TITLE
(DO NOT MERGE UNTIL ENTIRE TEAM APPROVES) Warden digs to entity if stuck for 10 seconds

### DIFF
--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -85,7 +85,6 @@ public class WardenEntity extends HostileEntity {
     protected void initGoals() {
         this.goalSelector.add(1, new SwimGoal(this));
         this.goalSelector.add(2, new WardenGoal(this, speed));
-        this.goalSelector.add(1, new WanderAroundGoal(this, 0.3));
     }
     @Override
     public void emitGameEvent(GameEvent event, @Nullable Entity entity, BlockPos pos) {}

--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -133,7 +133,7 @@ public class WardenEntity extends HostileEntity {
             this.timeStuck=0;
             this.stuckPos=this.getBlockPos();
         }
-        if(this.timeStuck>=200 && !this.isDiggingToLocation && this.hasEmerged) {
+        if(this.timeStuck>=200 && !this.isDiggingToLocation && this.hasEmerged && world.getTime()-this.vibrationTimer<200) {
             this.handleStatus((byte) 8);
         }
         if(this.emergeTicksLeft>-2 && this.hasEmerged && this.isDiggingToLocation) {

--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -35,6 +35,9 @@ import net.minecraft.world.event.PositionSourceType;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.Optional;
 
 public class WardenEntity extends HostileEntity {
@@ -50,6 +53,8 @@ public class WardenEntity extends HostileEntity {
     public BlockPos lasteventpos;
     public World lasteventworld;
     public LivingEntity lastevententity;
+    public ArrayList<UUID> entityList = new ArrayList<UUID>();
+    public ArrayList<Integer> susList = new ArrayList<Integer>();
 
     public BlockPos outPos;
 
@@ -262,11 +267,40 @@ public class WardenEntity extends HostileEntity {
                 }
             };
                 CreateVibration(this.world, lasteventpos, wardenPositionSource, WardenHead);
+            if (eventEntity!=null) {
+                addSuspicion(eventEntity);
+            }
             }
         this.lasteventpos = eventPos;
         this.lasteventworld = eventWorld;
         this.lastevententity = eventEntity;
     }
+    
+        public void addSuspicion(LivingEntity entity) {
+        if (!this.entityList.isEmpty()) {
+            if (this.entityList.contains(entity.getUuid())) {
+                int slot = this.entityList.indexOf(entity.getUuid());
+                this.susList.set(slot, this.susList.get(slot) + 1);
+            } else {
+                this.entityList.add(entity.getUuid());
+                this.susList.add(1);
+            }
+        } else {
+            this.entityList.add(entity.getUuid());
+            this.susList.add(1);
+        }
+    }
+
+    public int getSuspicion(UUID id) {
+        if (!this.entityList.isEmpty()) {
+            if (this.entityList.contains(id)) {
+                int slot = this.entityList.indexOf(id);
+                return this.susList.get(slot);
+            }
+        }
+        return 0;
+    }
+    
     public void newWarden(World world, BlockPos currentCheck) {
         if (currentCheck!=null) {
             WardenEntity warden = (WardenEntity) RegisterEntities.WARDEN.create(world);

--- a/src/main/java/frozenblock/wild/mod/fromAccurateSculk/ShriekCounter.java
+++ b/src/main/java/frozenblock/wild/mod/fromAccurateSculk/ShriekCounter.java
@@ -112,7 +112,7 @@ public class ShriekCounter {
         return !SculkTags.WARDEN_SPAWNABLE.contains(world.getBlockState(p).getBlock()) && !world.getBlockState(p).isAir() && world.getBlockState(p).getBlock()!=Blocks.WATER &&  world.getBlockState(p).getBlock()!=Blocks.LAVA;
     }
     public static boolean wardenNonCollide(BlockPos p, World world) {
-        if (SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up()).getBlock()) && SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up(2)).getBlock()) && SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up(3)).getBlock()) && SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up(4)).getBlock())) {
+        if (SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up()).getBlock()) && SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up(2)).getBlock()) && SculkTags.WARDEN_NON_COLLIDE.contains(world.getBlockState(p.up(3)).getBlock())) {
             return true;
         }
         return false;
@@ -143,5 +143,16 @@ public class ShriekCounter {
             world.playSound(null, play, RegisterSounds.ENTITY_WARDEN_CLOSEST, SoundCategory.NEUTRAL, 0.4F, 1F);
         }
     }
+
+    public static BlockPos wardenOutLocation(BlockPos pos, World world) {
+                for (int t = 1; t < 8; t++) {
+                    ArrayList<BlockPos> candidates = findBlock(pos.add(-1, 0, -1), t, true, world);
+                    if (!candidates.isEmpty()) {
+                            int ran = UniformIntProvider.create(0, candidates.size() - 1).get(world.getRandom());
+                            return candidates.get(ran);
+                    }
+                }
+        return null;
+        }
 
 }


### PR DESCRIPTION
IMPORTANT:
I wasn't sure if this would necessarily be agreed upon, so I put it into this pull request with... this title.
It's possible this could result in unwanted behavior, so I would appreciate this being play-tested IF this is agreed to be added to the mod. I know this code could be better, but that's out of my scope at the moment, as I don't think I'm experienced enough to actually improve it any further. I tried getting this to target the nearest entity, but that kept crashing the game- hence why I chose the method to choose an entity that I chose. It is possible to make it only target players, which would make this a bit better- however, lore-wise, the Warden doesn't know the difference between a spider and a player (I think)
If this shouldn't be added, I guess we could keep the stuff for tracking if it's stuck and maybe someone could find a use for it in the future.
I strongly encourage anyone and everyone to edit this pull request to improve it as much as possible.
