### PR TITLE
Sniffing & Less Glitchy Warden AI

### DIFF
--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -97,8 +97,8 @@ public class WardenEntity extends HostileEntity {
 
     protected void initGoals() {
         this.goalSelector.add(1, new SwimGoal(this));
-        this.goalSelector.add(3, new SniffGoal(this, speed));
-        this.goalSelector.add(2, new WardenGoal(this, speed));
+        this.goalSelector.add(2, new SniffGoal(this, speed));
+        this.goalSelector.add(3, new WardenGoal(this, speed));
         this.goalSelector.add(1, new WardenWanderGoal(this, 0.4));
     }
     @Override
@@ -166,10 +166,10 @@ public class WardenEntity extends HostileEntity {
         }
         //Sniffing
         if(this.sniffTicksLeft > 0) {
-            this.sniffTicksLeft--;
+            --this.sniffTicksLeft;
         }
         if(this.sniffCooldown > 0) {
-            this.sniffCooldown--;
+            --this.sniffCooldown;
         }
         if(this.sniffTicksLeft==0) {
             this.sniffTicksLeft=-1;

--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -464,6 +464,9 @@ public class WardenEntity extends HostileEntity {
         if(this.getBlockPos().getSquaredDistance(livingEntity.getBlockPos(), true)<=8) {
             total=total+1;
         }
+        if(event==GameEvent.PROJECTILE_LAND && total>1) {
+            total=total-1;
+        }
         return total;
     }
     public int overallAnger() {

--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -2,6 +2,7 @@ package frozenblock.wild.mod.entity;
 
 
 import frozenblock.wild.mod.liukrastapi.WardenGoal;
+import frozenblock.wild.mod.liukrastapi.WardenWanderGoal;
 import frozenblock.wild.mod.registry.RegisterAccurateSculk;
 import frozenblock.wild.mod.registry.RegisterSounds;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -48,6 +49,7 @@ public class WardenEntity extends HostileEntity {
     public BlockPos lasteventpos;
     public World lasteventworld;
     public LivingEntity lastevententity;
+    public LivingEntity navigationEntity;
     public IntArrayList entityList = new IntArrayList();
     public IntArrayList susList = new IntArrayList();
     public String trackingEntity = "null";
@@ -90,7 +92,7 @@ public class WardenEntity extends HostileEntity {
     protected void initGoals() {
         this.goalSelector.add(1, new SwimGoal(this));
         this.goalSelector.add(2, new WardenGoal(this, speed));
-        this.goalSelector.add(1, new WanderAroundGoal(this, 0.4));
+        this.goalSelector.add(1, new WardenWanderGoal(this, 0.4));
     }
     @Override
     public void emitGameEvent(GameEvent event, @Nullable Entity entity, BlockPos pos) {}
@@ -244,7 +246,10 @@ public class WardenEntity extends HostileEntity {
     }
 
     public void listen(BlockPos eventPos, World eventWorld, LivingEntity eventEntity, int suspicion) {
-        if (!(this.emergeTicksLeft > 0) && this.lasteventpos == eventPos && this.lasteventworld == eventWorld && this.lastevententity == eventEntity && this.world.getTime() - this.vibrationTimer >= 23) {
+        if (!(this.emergeTicksLeft > 0) && this.world.getTime() - this.vibrationTimer >= 23) {
+            this.lasteventpos = eventPos;
+            this.lasteventworld = eventWorld;
+            this.lastevententity = eventEntity;
             this.hasDetected = true;
             this.vibrationTimer = this.world.getTime();
             this.leaveTime = this.world.getTime() + 1200;
@@ -255,13 +260,13 @@ public class WardenEntity extends HostileEntity {
                 addSuspicion(eventEntity, suspicion);
             }
         }
-        this.lasteventpos = eventPos;
-        this.lasteventworld = eventWorld;
-        this.lastevententity = eventEntity;
     }
 
     public void sculkSensorListen(BlockPos eventPos, BlockPos vibrationPos, World eventWorld, LivingEntity eventEntity, int suspicion) {
         if (!(this.emergeTicksLeft > 0) && this.world.getTime() - this.vibrationTimer >= 23) {
+            this.lasteventpos = eventPos;
+            this.lastevententity = eventEntity;
+            this.lasteventworld = eventWorld;
             this.hasDetected = true;
             this.vibrationTimer = this.world.getTime();
             this.leaveTime = this.world.getTime() + 1200;
@@ -271,9 +276,6 @@ public class WardenEntity extends HostileEntity {
             if (eventEntity != null) {
                 addSuspicion(eventEntity, suspicion);
             }
-            this.lasteventpos = eventPos;
-            this.lastevententity = eventEntity;
-            this.lasteventworld = eventWorld;
         }
     }
 
@@ -364,7 +366,7 @@ public class WardenEntity extends HostileEntity {
         return value;
     }
     public LivingEntity getTrackingEntity() {
-        Box box = new Box(this.getBlockPos().add(-20,-20,-20), this.getBlockPos().add(20,20,20));
+        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
         List<LivingEntity> entities = this.world.getNonSpectatingEntities(LivingEntity.class, box);
         if (!entities.isEmpty()) {
             for (LivingEntity target : entities) {
@@ -377,9 +379,6 @@ public class WardenEntity extends HostileEntity {
     }
     public boolean canFollow(Entity entity, boolean mustBeTracking) {
         Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
-        if (this.getSuspicion(entity)>=15) {
-            box = new Box(this.getBlockPos().add(-20, -20, -20), this.getBlockPos().add(20, 20, 20));
-        }
         List<Entity> entities = world.getNonSpectatingEntities(Entity.class, box);
         if (!entities.isEmpty() && entities.contains(entity)) {
             if (mustBeTracking) {

--- a/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
+++ b/src/main/java/frozenblock/wild/mod/entity/WardenEntity.java
@@ -1,6 +1,7 @@
 package frozenblock.wild.mod.entity;
 
 
+import frozenblock.wild.mod.liukrastapi.MathAddon;
 import frozenblock.wild.mod.liukrastapi.SniffGoal;
 import frozenblock.wild.mod.liukrastapi.WardenGoal;
 import frozenblock.wild.mod.liukrastapi.WardenWanderGoal;
@@ -383,12 +384,14 @@ public class WardenEntity extends HostileEntity {
         return value;
     }
     public LivingEntity getTrackingEntity() {
-        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
+        Box box = new Box(this.getBlockPos().add(-18,-18,-18), this.getBlockPos().add(18,18,18));
         List<LivingEntity> entities = this.world.getNonSpectatingEntities(LivingEntity.class, box);
         if (!entities.isEmpty()) {
             for (LivingEntity target : entities) {
                 if (Objects.equals(this.trackingEntity, target.getUuidAsString())) {
+                    if (MathAddon.distance(target.getX(), target.getY(), target.getZ(), this.getX(), this.getY(), this.getZ()) <= 16) {
                     return target;
+                    }
                 }
             }
         }

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
@@ -118,26 +118,28 @@ public class SniffGoal extends Goal {
                 Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
                 List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
                 LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
-                if (chosen!=null) {
+                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
                     sniffEntity=chosen;
                 }
             }
         }
 
         if (sniffEntity!=null) {
-            int extraSuspicion=0;
-            this.mob.sniffTicksLeft=34;
-            this.mob.sniffCooldown=134;
-            this.mob.sniffX=sniffEntity.getBlockPos().getX();
-            this.mob.sniffY=sniffEntity.getBlockPos().getY();
-            this.mob.sniffZ=sniffEntity.getBlockPos().getZ();
-            this.mob.vibrationTimer=this.mob.getWorld().getTime();
-            this.mob.getWorld().playSound(null, this.mob.getCameraBlockPos(), RegisterSounds.ENTITY_WARDEN_SNIFF, SoundCategory.HOSTILE, 1F, 1F);
-            if(this.mob.getBlockPos().getSquaredDistance(sniffEntity.getBlockPos(), true)<=8) {
-                extraSuspicion=extraSuspicion+1;
+            if (MathAddon.distance(sniffEntity.getX(), sniffEntity.getY(), sniffEntity.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ()) <= 16) {
+                int extraSuspicion = 0;
+                this.mob.sniffTicksLeft = 34;
+                this.mob.sniffCooldown = 134;
+                this.mob.sniffX = sniffEntity.getBlockPos().getX();
+                this.mob.sniffY = sniffEntity.getBlockPos().getY();
+                this.mob.sniffZ = sniffEntity.getBlockPos().getZ();
+                this.mob.vibrationTimer = this.mob.getWorld().getTime();
+                this.mob.getWorld().playSound(null, this.mob.getCameraBlockPos(), RegisterSounds.ENTITY_WARDEN_SNIFF, SoundCategory.HOSTILE, 1F, 1F);
+                if (this.mob.getBlockPos().getSquaredDistance(sniffEntity.getBlockPos(), true) <= 8) {
+                    extraSuspicion = extraSuspicion + 1;
+                }
+                this.mob.addSuspicion(sniffEntity, UniformIntProvider.create(1, 2).get(this.mob.getRandom()) + extraSuspicion);
+                this.mob.leaveTime = this.mob.getWorld().getTime() + 1200;
             }
-            this.mob.addSuspicion(sniffEntity, UniformIntProvider.create(1,2).get(this.mob.getRandom()) + extraSuspicion);
-            this.mob.leaveTime=this.mob.getWorld().getTime()+1200;
         }
     }
 

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
@@ -1,0 +1,146 @@
+package frozenblock.wild.mod.liukrastapi;
+
+import frozenblock.wild.mod.entity.WardenEntity;
+import frozenblock.wild.mod.registry.RegisterEntities;
+import frozenblock.wild.mod.registry.RegisterSounds;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.TargetPredicate;
+import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.intprovider.UniformIntProvider;
+
+import java.util.List;
+
+
+public class SniffGoal extends Goal {
+    private int cooldown;
+
+    private double VX;
+    private double VY;
+    private double VZ;
+
+    private boolean ROAR;
+
+    private final WardenEntity mob;
+    private final double speed;
+
+    public SniffGoal(WardenEntity mob, double speed) {
+        this.mob = mob;
+        this.speed = speed;
+    }
+
+
+    public boolean canStart() {
+        boolean exit = false;
+        LivingEntity sniffEntity = null;
+        if (this.mob.mostSuspiciousAround()!=null) {
+            sniffEntity=this.mob.mostSuspiciousAround();
+        }
+        if (this.mob.getTrackingEntity()!=null) {
+            sniffEntity=this.mob.getTrackingEntity();
+        }
+        if (sniffEntity==null) {
+            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
+            sniffEntity=closestPlayer;
+            if (closestPlayer==null) {
+                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
+                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
+                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
+                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
+                    sniffEntity=chosen;
+                }
+            }
+        }
+        if (this.mob.emergeTicksLeft>0) {
+            return false;
+        }
+        if (this.mob.getWorld().getTime()-this.mob.vibrationTimer>160 && sniffEntity!=null) {
+            exit = true;
+        }
+
+        int r = this.mob.getRoarTicksLeft1();
+        if (r > 0) {
+            exit = false;
+        }
+
+        return exit && UniformIntProvider.create(0,3).get(this.mob.getRandom())>0;
+    }
+
+    public boolean shouldContinue() {
+        boolean exit = false;
+        LivingEntity sniffEntity = null;
+        if (this.mob.mostSuspiciousAround()!=null) {
+            sniffEntity=this.mob.mostSuspiciousAround();
+        }
+        if (this.mob.getTrackingEntity()!=null) {
+            sniffEntity=this.mob.getTrackingEntity();
+        }
+        if (sniffEntity==null) {
+            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
+            sniffEntity=closestPlayer;
+            if (closestPlayer==null) {
+                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
+                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
+                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
+                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
+                    sniffEntity=chosen;
+                }
+            }
+        }
+        if (this.mob.emergeTicksLeft>0) {
+            return false;
+        }
+        if (this.mob.getWorld().getTime()-this.mob.vibrationTimer>160 && sniffEntity!=null) {
+            exit = true;
+        }
+
+        int r = this.mob.getRoarTicksLeft1();
+        if (r > 0) {
+            exit = false;
+        }
+
+        return exit && UniformIntProvider.create(0,3).get(this.mob.getRandom())>0;
+    }
+
+    public void start() {
+        LivingEntity sniffEntity = null;
+        if (this.mob.mostSuspiciousAround()!=null) {
+            sniffEntity=this.mob.mostSuspiciousAround();
+        }
+        if (this.mob.getTrackingEntity()!=null) {
+            sniffEntity=this.mob.getTrackingEntity();
+        }
+        if (sniffEntity==null) {
+            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
+            sniffEntity=closestPlayer;
+            if (closestPlayer==null) {
+                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
+                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
+                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
+                if (chosen!=null) {
+                    sniffEntity=chosen;
+                }
+            }
+        }
+
+        if (sniffEntity!=null) {
+            int extraSuspicion=0;
+            this.mob.sniffTicksLeft=34;
+            this.mob.sniffCooldown=134;
+            this.mob.sniffX=sniffEntity.getBlockPos().getX();
+            this.mob.sniffY=sniffEntity.getBlockPos().getY();
+            this.mob.sniffZ=sniffEntity.getBlockPos().getZ();
+            this.mob.vibrationTimer=this.mob.getWorld().getTime();
+            this.mob.getWorld().playSound(null, this.mob.getCameraBlockPos(), RegisterSounds.ENTITY_WARDEN_SNIFF, SoundCategory.HOSTILE, 1F, 1F);
+            if(this.mob.getBlockPos().getSquaredDistance(sniffEntity.getBlockPos(), true)<=8) {
+                extraSuspicion=extraSuspicion+1;
+            }
+            this.mob.addSuspicion(sniffEntity, UniformIntProvider.create(1,2).get(this.mob.getRandom()) + extraSuspicion);
+            this.mob.leaveTime=this.mob.getWorld().getTime()+1200;
+        }
+    }
+
+    public void stop() {
+    }
+}

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
@@ -1,473 +1,146 @@
-package frozenblock.wild.mod.entity;
+package frozenblock.wild.mod.liukrastapi;
 
-
-import frozenblock.wild.mod.liukrastapi.SniffGoal;
-import frozenblock.wild.mod.liukrastapi.WardenGoal;
-import frozenblock.wild.mod.liukrastapi.WardenWanderGoal;
-import frozenblock.wild.mod.registry.RegisterAccurateSculk;
+import frozenblock.wild.mod.entity.WardenEntity;
+import frozenblock.wild.mod.registry.RegisterEntities;
 import frozenblock.wild.mod.registry.RegisterSounds;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
-import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.block.BlockState;
-import net.minecraft.entity.*;
-import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.DefaultAttributeContainer;
-import net.minecraft.entity.attribute.EntityAttributes;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.mob.*;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.network.PacketByteBuf;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.world.ServerWorld;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.TargetPredicate;
+import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvent;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.world.LocalDifficulty;
-import net.minecraft.world.ServerWorldAccess;
-import net.minecraft.world.Vibration;
-import net.minecraft.world.World;
-import net.minecraft.world.event.*;
-import org.jetbrains.annotations.Nullable;
+import net.minecraft.util.math.intprovider.UniformIntProvider;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
-public class WardenEntity extends HostileEntity {
 
-    private int attackTicksLeft1;
+public class SniffGoal extends Goal {
+    private int cooldown;
 
-    private int roarTicksLeft1;
+    private double VX;
+    private double VY;
+    private double VZ;
 
-    private double roarAnimationProgress;
+    private boolean ROAR;
 
-    private static final double speed = 0.4D;
+    private final WardenEntity mob;
+    private final double speed;
 
-    public BlockPos lasteventpos;
-    public World lasteventworld;
-    public LivingEntity lastevententity;
-    public LivingEntity navigationEntity;
-    public IntArrayList entityList = new IntArrayList();
-    public IntArrayList susList = new IntArrayList();
-    public String trackingEntity = "null";
-    public int followingEntity;
-
-    public boolean hasDetected=false;
-    public int emergeTicksLeft;
-    public boolean hasEmerged;
-    public int followTicksLeft;
-    public long vibrationTimer = 0;
-    public long leaveTime;
-    protected int delay = 0;
-    protected int distance;
-
-    public int hearbeatTime = 60;
-    public long nextHeartBeat;
-    public int timeStuck=0;
-    public BlockPos stuckPos;
-    public long timeSinceLastRecalculation;
-    public int sniffTicksLeft;
-    public int sniffCooldown;
-    public int sniffX;
-    public int sniffY;
-    public int sniffZ;
-
-    public WardenEntity(EntityType<? extends HostileEntity> entityType, World world) {
-        super(entityType, world);
-    }
-
-    public static DefaultAttributeContainer.Builder createWardenAttributes() {
-
-        return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 500.0D).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, speed).add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 1.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 31.0D);
-    }
-
-    @Override
-    @Nullable
-    public EntityData initialize(ServerWorldAccess world, LocalDifficulty difficulty, SpawnReason spawnReason, @Nullable EntityData entityData, @Nullable NbtCompound entityNbt) {
-        this.handleStatus((byte) 5);
-        this.leaveTime=this.world.getTime()+1200;
-        return super.initialize(world, difficulty, spawnReason, entityData, entityNbt);
+    public SniffGoal(WardenEntity mob, double speed) {
+        this.mob = mob;
+        this.speed = speed;
     }
 
 
-    protected void initGoals() {
-        this.goalSelector.add(1, new SwimGoal(this));
-        this.goalSelector.add(3, new SniffGoal(this, speed));
-        this.goalSelector.add(2, new WardenGoal(this, speed));
-        this.goalSelector.add(1, new WardenWanderGoal(this, 0.4));
-    }
-    @Override
-    public void emitGameEvent(GameEvent event, @Nullable Entity entity, BlockPos pos) {}
-    @Override
-    public void emitGameEvent(GameEvent event, @Nullable Entity entity) {}
-    @Override
-    public void emitGameEvent(GameEvent event, BlockPos pos) {}
-    @Override
-    public void emitGameEvent(GameEvent event) {}
-
-
-    public void tickMovement() {
-        if(this.attackTicksLeft1 > 0) {
-            --this.attackTicksLeft1;
+    public boolean canStart() {
+        boolean exit = false;
+        LivingEntity sniffEntity = null;
+        if (this.mob.mostSuspiciousAround()!=null) {
+            sniffEntity=this.mob.mostSuspiciousAround();
         }
-        if(this.roarTicksLeft1 > 0) {
-            --this.roarTicksLeft1;
+        if (this.mob.getTrackingEntity()!=null) {
+            sniffEntity=this.mob.getTrackingEntity();
         }
-        if(this.emergeTicksLeft > 0 && !this.hasEmerged) {
-            digParticles(this.world, this.getBlockPos(), this.emergeTicksLeft);
-            this.setInvulnerable(true);
-            this.setVelocity(0,0,0);
-            this.emergeTicksLeft--;
-        }
-        if (this.emergeTicksLeft==0 && !this.hasEmerged) {
-            this.setInvulnerable(false);
-            this.hasEmerged=true;
-            this.emergeTicksLeft=-1;
-        }
-        if(this.emergeTicksLeft > 0 && this.hasEmerged) {
-            digParticles(this.world, this.getBlockPos(), this.emergeTicksLeft);
-            this.setInvulnerable(true);
-            this.setVelocity(0,0,0);
-            --this.emergeTicksLeft;
-        }
-        if (this.emergeTicksLeft==0 && this.hasEmerged) {
-            this.remove(RemovalReason.DISCARDED);
-        }
-        if(world.getTime()==this.leaveTime) {
-            this.handleStatus((byte) 6);
-        }
-        //Movement
-        if(this.stuckPos!=null && this.getBlockPos().getSquaredDistance(this.stuckPos)<2 && this.hasEmerged && this.hasDetected && !(this.sniffTicksLeft>0)) {
-            this.timeStuck++;
-        } else {
-            this.timeStuck=0;
-            this.stuckPos=this.getBlockPos();
-        }
-        if(this.timeStuck>=60 && this.hasEmerged && this.world.getTime()-this.vibrationTimer<120 && this.world.getTime()-this.timeSinceLastRecalculation>60 && !(this.sniffTicksLeft>0)) {
-            this.getNavigation().recalculatePath();
-            this.timeSinceLastRecalculation=this.world.getTime();
-        }
-        if(this.followTicksLeft > 0) {
-            --this.followTicksLeft;
-            if (this.world.getEntityById(this.followingEntity)!=null) {
-                Entity entity = this.world.getEntityById(this.followingEntity);
-                assert entity != null;
-                if (entity.isAlive() && canFollow(entity, true) && !(this.sniffTicksLeft>0)) {
-                    this.getNavigation().startMovingTo(entity.getX(), entity.getY(), entity.getZ(), (speed + (MathHelper.clamp(this.getSuspicion(entity), 0, 15) * 0.03) + (this.overallAnger() * 0.004)));
-                } else {
-                    this.followTicksLeft=0;
+        if (sniffEntity==null) {
+            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
+            sniffEntity=closestPlayer;
+            if (closestPlayer==null) {
+                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
+                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
+                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
+                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
+                    sniffEntity=chosen;
                 }
             }
         }
-        //Sniffing
-        if(this.sniffTicksLeft > 0) {
-            this.sniffTicksLeft--;
+        if (this.mob.emergeTicksLeft>0) {
+            return false;
         }
-        if(this.sniffCooldown > 0) {
-            this.sniffCooldown--;
-        }
-        if(this.sniffTicksLeft==0) {
-            this.sniffTicksLeft=-1;
-            this.getNavigation().startMovingTo(sniffX, sniffY, sniffZ, speed + (this.overallAnger()*0.012));
-        }
-        //Heartbeat
-        this.hearbeatTime = (int) (60 - ((MathHelper.clamp(this.overallAnger(),0,15)*3.3)));
-        if (this.world.getTime()>=this.nextHeartBeat) {
-            this.world.playSound(null, this.getBlockPos().up(), RegisterSounds.ENTITY_WARDEN_HEARTBEAT, SoundCategory.HOSTILE, 1F, 1F);
-            this.nextHeartBeat=this.world.getTime()+hearbeatTime;
-        }
-        super.tickMovement();
-    }
-
-    private float getAttackDamage() {
-        return (float)this.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
-    }
-
-    public void setRoarAnimationProgress(double a) {
-        this.roarAnimationProgress = a;
-    }
-    public void roar() {
-        this.attackTicksLeft1 = 10;
-        this.world.sendEntityStatus(this, (byte)3);
-    }
-
-    public boolean tryAttack(Entity target) {
-        float f = this.getAttackDamage();
-        float g = (int)f > 0 ? f / 2.0F + (float)this.random.nextInt((int)f) : f;
-        boolean bl = target.damage(DamageSource.mob(this), g);
-        if (bl) {
-            this.attackTicksLeft1 = 10;
-            this.world.sendEntityStatus(this, (byte)4);
-            target.setVelocity(target.getVelocity().add(0.0D, 0.4000000059604645D, 0.0D));
-            this.applyDamageEffects(this, target);
-            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_SLIGHTLY_ANGRY, SoundCategory.HOSTILE, 1.0F,1.0F);
-        }
-        return bl;
-    }
-
-    public int getAttackTicksLeft1() {
-        return this.attackTicksLeft1;
-    }
-
-    public double getRoarAnimationProgress() {
-        return this.roarAnimationProgress;
-    }
-
-    public int getRoarTicksLeft1() {
-        return this.roarTicksLeft1;
-    }
-
-    public void handleStatus(byte status) {
-        if (status == 4) {
-            this.attackTicksLeft1 = 10;
-            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_AMBIENT, SoundCategory.HOSTILE, 1.0F,1.0F);
-        } else if(status == 3) {
-            this.roarTicksLeft1 = 10;
-        } else if(status == 5) {
-            //Emerging
-            this.emergeTicksLeft=120;
-            this.hasEmerged=false;
-            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_EMERGE, SoundCategory.HOSTILE, 1F, 1F);
-        } else if(status == 6) {
-            //Digging Back
-            this.emergeTicksLeft=60;
-            this.hasEmerged=true;
-            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_DIG, SoundCategory.HOSTILE, 1F, 1F);
-        }  else {
-            super.handleStatus(status);
+        if (this.mob.getWorld().getTime()-this.mob.vibrationTimer>160 && sniffEntity!=null) {
+            exit = true;
         }
 
-    }
-
-    public void digParticles(World world, BlockPos pos, int ticks) {
-        PacketByteBuf buf = PacketByteBufs.create();
-        buf.writeBlockPos(pos);
-        buf.writeInt(ticks);
-        for (ServerPlayerEntity player : PlayerLookup.around((ServerWorld) world, pos, 32)) {
-            ServerPlayNetworking.send(player, RegisterAccurateSculk.WARDEN_DIG_PARTICLES, buf);
+        int r = this.mob.getRoarTicksLeft1();
+        if (r > 0) {
+            exit = false;
         }
+
+        return exit && UniformIntProvider.create(0,3).get(this.mob.getRandom())>0;
     }
 
-    protected SoundEvent getAmbientSound(){return RegisterSounds.ENTITY_WARDEN_AMBIENT;}
-
-    protected SoundEvent getHurtSound(DamageSource source) {return RegisterSounds.ENTITY_WARDEN_HURT;}
-
-    protected SoundEvent getStepSound() {return RegisterSounds.ENTITY_WARDEN_STEP;}
-
-    protected void playStepSound(BlockPos pos, BlockState state) {
-        this.playSound(this.getStepSound(), 1.0F, 1.0F);
-    }
-
-    public void listen(BlockPos eventPos, World eventWorld, LivingEntity eventEntity, int suspicion) {
-        if (!(this.emergeTicksLeft > 0) && this.world.getTime() - this.vibrationTimer >= 23) {
-            this.lasteventpos = eventPos;
-            this.lasteventworld = eventWorld;
-            this.lastevententity = eventEntity;
-            this.hasDetected = true;
-            this.vibrationTimer = this.world.getTime();
-            this.leaveTime = this.world.getTime() + 1200;
-            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_VIBRATION, SoundCategory.HOSTILE, 0.5F, world.random.nextFloat() * 0.2F + 0.8F);
-            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_SLIGHTLY_ANGRY, SoundCategory.HOSTILE, 1.0F, world.random.nextFloat() * 0.2F + 0.8F);
-            CreateVibration(this.world, this, lasteventpos);
-            if (eventEntity != null) {
-                addSuspicion(eventEntity, suspicion);
-            }
+    public boolean shouldContinue() {
+        boolean exit = false;
+        LivingEntity sniffEntity = null;
+        if (this.mob.mostSuspiciousAround()!=null) {
+            sniffEntity=this.mob.mostSuspiciousAround();
         }
-    }
-
-    public void sculkSensorListen(BlockPos eventPos, BlockPos vibrationPos, World eventWorld, LivingEntity eventEntity, int suspicion) {
-        if (!(this.emergeTicksLeft > 0) && this.world.getTime() - this.vibrationTimer >= 23) {
-            this.lasteventpos = eventPos;
-            this.lastevententity = eventEntity;
-            this.lasteventworld = eventWorld;
-            this.hasDetected = true;
-            this.vibrationTimer = this.world.getTime();
-            this.leaveTime = this.world.getTime() + 1200;
-            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_VIBRATION, SoundCategory.HOSTILE, 0.5F, world.random.nextFloat() * 0.2F + 0.8F);
-            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_SLIGHTLY_ANGRY, SoundCategory.HOSTILE, 1.0F, world.random.nextFloat() * 0.2F + 0.8F);
-            CreateVibration(this.world, this, vibrationPos);
-            if (eventEntity != null) {
-                addSuspicion(eventEntity, suspicion);
-            }
+        if (this.mob.getTrackingEntity()!=null) {
+            sniffEntity=this.mob.getTrackingEntity();
         }
-    }
-
-    public void CreateVibration(World world, WardenEntity warden, BlockPos blockPos2) {
-        EntityPositionSource wardenPositionSource = new EntityPositionSource(this.getId()) {
-            @Override
-            public Optional<BlockPos> getPos(World world) {
-                return Optional.of(warden.getCameraBlockPos());
-            }
-            @Override
-            public PositionSourceType<?> getType() {
-                return PositionSourceType.ENTITY;
-            }
-        };
-        this.delay = this.distance = (int)Math.floor(Math.sqrt(warden.getCameraBlockPos().getSquaredDistance(blockPos2, false))) * 2;
-        ((ServerWorld)world).sendVibrationPacket(new Vibration(blockPos2, wardenPositionSource, this.delay));
-    }
-
-    public void followForTicks(LivingEntity entity, int ticks) {
-        this.followingEntity = entity.getId();
-        this.followTicksLeft = ticks;
-    }
-
-    public void addSuspicion(LivingEntity entity, int suspicion) {
-        if (!this.entityList.isEmpty()) {
-            if (this.entityList.contains(entity.getUuid().hashCode())) {
-                int slot = this.entityList.indexOf(entity.getUuid().hashCode());
-                this.susList.set(slot, this.susList.getInt(slot) + suspicion);
-                if (this.susList.getInt(slot)>=15 && this.getTrackingEntity()==null) {
-                    this.trackingEntity=entity.getUuidAsString();
-                    this.world.playSound(null, this.getBlockPos().up(), RegisterSounds.ENTITY_WARDEN_ROAR, SoundCategory.HOSTILE, 1F, 1F);
-                    this.roar();
-                }
-            } else {
-                this.entityList.add(entity.getUuid().hashCode());
-                this.susList.add(suspicion);
-            }
-        } else {
-            this.entityList.add(entity.getUuid().hashCode());
-            this.susList.add(suspicion);
-        }
-    }
-
-    public int getSuspicion(Entity entity) {
-        if (!this.entityList.isEmpty() && entity!=null) {
-            if (this.entityList.contains(entity.getUuid().hashCode())) {
-                int slot = this.entityList.indexOf(entity.getUuid().hashCode());
-                return this.susList.getInt(slot);
-            }
-        }
-        return 0;
-    }
-
-    public int getHighestSuspicionInt() {
-        int highest = 0;
-        if (!this.susList.isEmpty()) {
-            for (int i=0; i<this.susList.size(); i++) {
-                if (this.susList.getInt(i)>highest) {
-                    highest=this.susList.getInt(i);
+        if (sniffEntity==null) {
+            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
+            sniffEntity=closestPlayer;
+            if (closestPlayer==null) {
+                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
+                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
+                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
+                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
+                    sniffEntity=chosen;
                 }
             }
         }
-        return highest;
+        if (this.mob.emergeTicksLeft>0) {
+            return false;
+        }
+        if (this.mob.getWorld().getTime()-this.mob.vibrationTimer>160 && sniffEntity!=null) {
+            exit = true;
+        }
+
+        int r = this.mob.getRoarTicksLeft1();
+        if (r > 0) {
+            exit = false;
+        }
+
+        return exit && UniformIntProvider.create(0,3).get(this.mob.getRandom())>0;
     }
 
-    public LivingEntity mostSuspiciousAround() {
-        int highest = 0;
-        LivingEntity most = null;
-        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
-        List<LivingEntity> entities = world.getNonSpectatingEntities(LivingEntity.class, box);
-        if (!entities.isEmpty()) {
-            for (LivingEntity target : entities) {
-                if (this.getBlockPos().getSquaredDistance(target.getBlockPos())<=16) {
-                    if (this.getSuspicion(target)>highest) {
-                        highest = this.getSuspicion(target);
-                        most = target;
-                    }
+    public void start() {
+        LivingEntity sniffEntity = null;
+        if (this.mob.mostSuspiciousAround()!=null) {
+            sniffEntity=this.mob.mostSuspiciousAround();
+        }
+        if (this.mob.getTrackingEntity()!=null) {
+            sniffEntity=this.mob.getTrackingEntity();
+        }
+        if (sniffEntity==null) {
+            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
+            sniffEntity=closestPlayer;
+            if (closestPlayer==null) {
+                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
+                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
+                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
+                if (chosen!=null) {
+                    sniffEntity=chosen;
                 }
             }
         }
-        return most;
-    }
-    public int mostSuspiciousAroundInt() {
-        int value=0;
-        if (mostSuspiciousAround()!=null) {
-            value=this.getSuspicion(mostSuspiciousAround());
-        }
-        return value;
-    }
-    public LivingEntity getTrackingEntity() {
-        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
-        List<LivingEntity> entities = this.world.getNonSpectatingEntities(LivingEntity.class, box);
-        if (!entities.isEmpty()) {
-            for (LivingEntity target : entities) {
-                if (Objects.equals(this.trackingEntity, target.getUuidAsString())) {
-                    return target;
-                }
+
+        if (sniffEntity!=null) {
+            int extraSuspicion=0;
+            this.mob.sniffTicksLeft=34;
+            this.mob.sniffCooldown=134;
+            this.mob.sniffX=sniffEntity.getBlockPos().getX();
+            this.mob.sniffY=sniffEntity.getBlockPos().getY();
+            this.mob.sniffZ=sniffEntity.getBlockPos().getZ();
+            this.mob.vibrationTimer=this.mob.getWorld().getTime();
+            this.mob.getWorld().playSound(null, this.mob.getCameraBlockPos(), RegisterSounds.ENTITY_WARDEN_SNIFF, SoundCategory.HOSTILE, 1F, 1F);
+            if(this.mob.getBlockPos().getSquaredDistance(sniffEntity.getBlockPos(), true)<=8) {
+                extraSuspicion=extraSuspicion+1;
             }
+            this.mob.addSuspicion(sniffEntity, UniformIntProvider.create(1,2).get(this.mob.getRandom()) + extraSuspicion);
+            this.mob.leaveTime=this.mob.getWorld().getTime()+1200;
         }
-        return null;
-    }
-    public boolean canFollow(Entity entity, boolean mustBeTracking) {
-        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
-        List<Entity> entities = world.getNonSpectatingEntities(Entity.class, box);
-        if (!entities.isEmpty() && entities.contains(entity)) {
-            if (mustBeTracking) {
-                if (entity == this.getTrackingEntity()) {
-                    return true;
-                }
-            } else {
-                return true;
-            }
-        }
-        return false;
-    }
-    public void writeCustomDataToNbt(NbtCompound nbt) {
-        super.writeCustomDataToNbt(nbt);
-        nbt.putLong("vibrationTimer", this.vibrationTimer);
-        nbt.putLong("leaveTime", this.leaveTime);
-        nbt.putInt("emergeTicksLeft", this.emergeTicksLeft);
-        nbt.putBoolean("hasEmerged", this.hasEmerged);
-        nbt.putIntArray("entityList", this.entityList);
-        nbt.putIntArray("susList", this.susList);
-        nbt.putString("trackingEntity", this.trackingEntity);
-        nbt.putInt("followTicksLeft", this.followTicksLeft);
-        nbt.putInt("followingEntity", this.followingEntity);
-        nbt.putInt("sniffTicksLeft", this.sniffTicksLeft);
-        nbt.putInt("sniffCooldown", this.sniffCooldown);
-        nbt.putInt("sniffX", this.sniffX);
-        nbt.putInt("sniffY", this.sniffY);
-        nbt.putInt("sniffZ", this.sniffZ);
-    }
-    public void readCustomDataFromNbt(NbtCompound nbt) {
-        super.readCustomDataFromNbt(nbt);
-        this.vibrationTimer = nbt.getLong("vibrationTimer");
-        this.leaveTime = nbt.getLong("leaveTime");
-        this.emergeTicksLeft = nbt.getInt("emergeTicksLeft");
-        this.hasEmerged = nbt.getBoolean("hasEmerged");
-        this.entityList = IntArrayList.wrap(nbt.getIntArray("entityList"));
-        this.susList = IntArrayList.wrap(nbt.getIntArray("susList"));
-        this.trackingEntity = nbt.getString("trackingEntity");
-        this.followTicksLeft = nbt.getInt("followTicksLeft");
-        this.followingEntity = nbt.getInt("followingEntity");
-        this.sniffTicksLeft = nbt.getInt("sniffTicksLeft");
-        this.sniffCooldown = nbt.getInt("sniffCooldown");
-        this.sniffX = nbt.getInt("sniffX");
-        this.sniffY = nbt.getInt("sniffY");
-        this.sniffZ = nbt.getInt("sniffZ");
     }
 
-    public int eventSuspicionValue(GameEvent event, LivingEntity livingEntity) {
-        int total=1;
-        EntityType entity=livingEntity.getType();
-        if (entity==EntityType.PLAYER) {
-            total=total+2;
-        }
-        if (entity==EntityType.IRON_GOLEM) { //They're loud, you know?
-            total=total+1;
-        }
-        if (entity==EntityType.VILLAGER) { //It's similar to a player, you know?
-            total=total+1;
-        }
-        if (entity==EntityType.WITHER) { //It's loud, you know?
-            total=total+1;
-        }
-        if(this.getBlockPos().getSquaredDistance(livingEntity.getBlockPos(), true)<=8) {
-            total=total+1;
-        }
-        return total;
-    }
-    public int overallAnger() {
-        int anger=0;
-        for (int i=0; i<this.susList.size(); i++) {
-            anger=anger+this.susList.getInt(i);
-        }
-        return MathHelper.clamp(anger,0,25);
+    public void stop() {
     }
 }

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/SniffGoal.java
@@ -1,146 +1,473 @@
-package frozenblock.wild.mod.liukrastapi;
+package frozenblock.wild.mod.entity;
 
-import frozenblock.wild.mod.entity.WardenEntity;
-import frozenblock.wild.mod.registry.RegisterEntities;
+
+import frozenblock.wild.mod.liukrastapi.SniffGoal;
+import frozenblock.wild.mod.liukrastapi.WardenGoal;
+import frozenblock.wild.mod.liukrastapi.WardenWanderGoal;
+import frozenblock.wild.mod.registry.RegisterAccurateSculk;
 import frozenblock.wild.mod.registry.RegisterSounds;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.ai.TargetPredicate;
-import net.minecraft.entity.ai.goal.Goal;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.*;
+import net.minecraft.entity.ai.goal.*;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.mob.*;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
-import net.minecraft.util.math.intprovider.UniformIntProvider;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.LocalDifficulty;
+import net.minecraft.world.ServerWorldAccess;
+import net.minecraft.world.Vibration;
+import net.minecraft.world.World;
+import net.minecraft.world.event.*;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
+public class WardenEntity extends HostileEntity {
 
-public class SniffGoal extends Goal {
-    private int cooldown;
+    private int attackTicksLeft1;
 
-    private double VX;
-    private double VY;
-    private double VZ;
+    private int roarTicksLeft1;
 
-    private boolean ROAR;
+    private double roarAnimationProgress;
 
-    private final WardenEntity mob;
-    private final double speed;
+    private static final double speed = 0.4D;
 
-    public SniffGoal(WardenEntity mob, double speed) {
-        this.mob = mob;
-        this.speed = speed;
+    public BlockPos lasteventpos;
+    public World lasteventworld;
+    public LivingEntity lastevententity;
+    public LivingEntity navigationEntity;
+    public IntArrayList entityList = new IntArrayList();
+    public IntArrayList susList = new IntArrayList();
+    public String trackingEntity = "null";
+    public int followingEntity;
+
+    public boolean hasDetected=false;
+    public int emergeTicksLeft;
+    public boolean hasEmerged;
+    public int followTicksLeft;
+    public long vibrationTimer = 0;
+    public long leaveTime;
+    protected int delay = 0;
+    protected int distance;
+
+    public int hearbeatTime = 60;
+    public long nextHeartBeat;
+    public int timeStuck=0;
+    public BlockPos stuckPos;
+    public long timeSinceLastRecalculation;
+    public int sniffTicksLeft;
+    public int sniffCooldown;
+    public int sniffX;
+    public int sniffY;
+    public int sniffZ;
+
+    public WardenEntity(EntityType<? extends HostileEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    public static DefaultAttributeContainer.Builder createWardenAttributes() {
+
+        return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 500.0D).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, speed).add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 1.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 31.0D);
+    }
+
+    @Override
+    @Nullable
+    public EntityData initialize(ServerWorldAccess world, LocalDifficulty difficulty, SpawnReason spawnReason, @Nullable EntityData entityData, @Nullable NbtCompound entityNbt) {
+        this.handleStatus((byte) 5);
+        this.leaveTime=this.world.getTime()+1200;
+        return super.initialize(world, difficulty, spawnReason, entityData, entityNbt);
     }
 
 
-    public boolean canStart() {
-        boolean exit = false;
-        LivingEntity sniffEntity = null;
-        if (this.mob.mostSuspiciousAround()!=null) {
-            sniffEntity=this.mob.mostSuspiciousAround();
+    protected void initGoals() {
+        this.goalSelector.add(1, new SwimGoal(this));
+        this.goalSelector.add(3, new SniffGoal(this, speed));
+        this.goalSelector.add(2, new WardenGoal(this, speed));
+        this.goalSelector.add(1, new WardenWanderGoal(this, 0.4));
+    }
+    @Override
+    public void emitGameEvent(GameEvent event, @Nullable Entity entity, BlockPos pos) {}
+    @Override
+    public void emitGameEvent(GameEvent event, @Nullable Entity entity) {}
+    @Override
+    public void emitGameEvent(GameEvent event, BlockPos pos) {}
+    @Override
+    public void emitGameEvent(GameEvent event) {}
+
+
+    public void tickMovement() {
+        if(this.attackTicksLeft1 > 0) {
+            --this.attackTicksLeft1;
         }
-        if (this.mob.getTrackingEntity()!=null) {
-            sniffEntity=this.mob.getTrackingEntity();
+        if(this.roarTicksLeft1 > 0) {
+            --this.roarTicksLeft1;
         }
-        if (sniffEntity==null) {
-            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
-            sniffEntity=closestPlayer;
-            if (closestPlayer==null) {
-                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
-                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
-                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
-                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
-                    sniffEntity=chosen;
+        if(this.emergeTicksLeft > 0 && !this.hasEmerged) {
+            digParticles(this.world, this.getBlockPos(), this.emergeTicksLeft);
+            this.setInvulnerable(true);
+            this.setVelocity(0,0,0);
+            this.emergeTicksLeft--;
+        }
+        if (this.emergeTicksLeft==0 && !this.hasEmerged) {
+            this.setInvulnerable(false);
+            this.hasEmerged=true;
+            this.emergeTicksLeft=-1;
+        }
+        if(this.emergeTicksLeft > 0 && this.hasEmerged) {
+            digParticles(this.world, this.getBlockPos(), this.emergeTicksLeft);
+            this.setInvulnerable(true);
+            this.setVelocity(0,0,0);
+            --this.emergeTicksLeft;
+        }
+        if (this.emergeTicksLeft==0 && this.hasEmerged) {
+            this.remove(RemovalReason.DISCARDED);
+        }
+        if(world.getTime()==this.leaveTime) {
+            this.handleStatus((byte) 6);
+        }
+        //Movement
+        if(this.stuckPos!=null && this.getBlockPos().getSquaredDistance(this.stuckPos)<2 && this.hasEmerged && this.hasDetected && !(this.sniffTicksLeft>0)) {
+            this.timeStuck++;
+        } else {
+            this.timeStuck=0;
+            this.stuckPos=this.getBlockPos();
+        }
+        if(this.timeStuck>=60 && this.hasEmerged && this.world.getTime()-this.vibrationTimer<120 && this.world.getTime()-this.timeSinceLastRecalculation>60 && !(this.sniffTicksLeft>0)) {
+            this.getNavigation().recalculatePath();
+            this.timeSinceLastRecalculation=this.world.getTime();
+        }
+        if(this.followTicksLeft > 0) {
+            --this.followTicksLeft;
+            if (this.world.getEntityById(this.followingEntity)!=null) {
+                Entity entity = this.world.getEntityById(this.followingEntity);
+                assert entity != null;
+                if (entity.isAlive() && canFollow(entity, true) && !(this.sniffTicksLeft>0)) {
+                    this.getNavigation().startMovingTo(entity.getX(), entity.getY(), entity.getZ(), (speed + (MathHelper.clamp(this.getSuspicion(entity), 0, 15) * 0.03) + (this.overallAnger() * 0.004)));
+                } else {
+                    this.followTicksLeft=0;
                 }
             }
         }
-        if (this.mob.emergeTicksLeft>0) {
-            return false;
+        //Sniffing
+        if(this.sniffTicksLeft > 0) {
+            this.sniffTicksLeft--;
         }
-        if (this.mob.getWorld().getTime()-this.mob.vibrationTimer>160 && sniffEntity!=null) {
-            exit = true;
+        if(this.sniffCooldown > 0) {
+            this.sniffCooldown--;
         }
-
-        int r = this.mob.getRoarTicksLeft1();
-        if (r > 0) {
-            exit = false;
+        if(this.sniffTicksLeft==0) {
+            this.sniffTicksLeft=-1;
+            this.getNavigation().startMovingTo(sniffX, sniffY, sniffZ, speed + (this.overallAnger()*0.012));
         }
-
-        return exit && UniformIntProvider.create(0,3).get(this.mob.getRandom())>0;
+        //Heartbeat
+        this.hearbeatTime = (int) (60 - ((MathHelper.clamp(this.overallAnger(),0,15)*3.3)));
+        if (this.world.getTime()>=this.nextHeartBeat) {
+            this.world.playSound(null, this.getBlockPos().up(), RegisterSounds.ENTITY_WARDEN_HEARTBEAT, SoundCategory.HOSTILE, 1F, 1F);
+            this.nextHeartBeat=this.world.getTime()+hearbeatTime;
+        }
+        super.tickMovement();
     }
 
-    public boolean shouldContinue() {
-        boolean exit = false;
-        LivingEntity sniffEntity = null;
-        if (this.mob.mostSuspiciousAround()!=null) {
-            sniffEntity=this.mob.mostSuspiciousAround();
+    private float getAttackDamage() {
+        return (float)this.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
+    }
+
+    public void setRoarAnimationProgress(double a) {
+        this.roarAnimationProgress = a;
+    }
+    public void roar() {
+        this.attackTicksLeft1 = 10;
+        this.world.sendEntityStatus(this, (byte)3);
+    }
+
+    public boolean tryAttack(Entity target) {
+        float f = this.getAttackDamage();
+        float g = (int)f > 0 ? f / 2.0F + (float)this.random.nextInt((int)f) : f;
+        boolean bl = target.damage(DamageSource.mob(this), g);
+        if (bl) {
+            this.attackTicksLeft1 = 10;
+            this.world.sendEntityStatus(this, (byte)4);
+            target.setVelocity(target.getVelocity().add(0.0D, 0.4000000059604645D, 0.0D));
+            this.applyDamageEffects(this, target);
+            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_SLIGHTLY_ANGRY, SoundCategory.HOSTILE, 1.0F,1.0F);
         }
-        if (this.mob.getTrackingEntity()!=null) {
-            sniffEntity=this.mob.getTrackingEntity();
+        return bl;
+    }
+
+    public int getAttackTicksLeft1() {
+        return this.attackTicksLeft1;
+    }
+
+    public double getRoarAnimationProgress() {
+        return this.roarAnimationProgress;
+    }
+
+    public int getRoarTicksLeft1() {
+        return this.roarTicksLeft1;
+    }
+
+    public void handleStatus(byte status) {
+        if (status == 4) {
+            this.attackTicksLeft1 = 10;
+            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_AMBIENT, SoundCategory.HOSTILE, 1.0F,1.0F);
+        } else if(status == 3) {
+            this.roarTicksLeft1 = 10;
+        } else if(status == 5) {
+            //Emerging
+            this.emergeTicksLeft=120;
+            this.hasEmerged=false;
+            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_EMERGE, SoundCategory.HOSTILE, 1F, 1F);
+        } else if(status == 6) {
+            //Digging Back
+            this.emergeTicksLeft=60;
+            this.hasEmerged=true;
+            world.playSound(null, this.getBlockPos(), RegisterSounds.ENTITY_WARDEN_DIG, SoundCategory.HOSTILE, 1F, 1F);
+        }  else {
+            super.handleStatus(status);
         }
-        if (sniffEntity==null) {
-            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
-            sniffEntity=closestPlayer;
-            if (closestPlayer==null) {
-                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
-                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
-                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
-                if (chosen!=null && MathAddon.distance(chosen.getX(), chosen.getY(), chosen.getZ(), this.mob.getX(), this.mob.getY(), this.mob.getZ())<=16) {
-                    sniffEntity=chosen;
+
+    }
+
+    public void digParticles(World world, BlockPos pos, int ticks) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeBlockPos(pos);
+        buf.writeInt(ticks);
+        for (ServerPlayerEntity player : PlayerLookup.around((ServerWorld) world, pos, 32)) {
+            ServerPlayNetworking.send(player, RegisterAccurateSculk.WARDEN_DIG_PARTICLES, buf);
+        }
+    }
+
+    protected SoundEvent getAmbientSound(){return RegisterSounds.ENTITY_WARDEN_AMBIENT;}
+
+    protected SoundEvent getHurtSound(DamageSource source) {return RegisterSounds.ENTITY_WARDEN_HURT;}
+
+    protected SoundEvent getStepSound() {return RegisterSounds.ENTITY_WARDEN_STEP;}
+
+    protected void playStepSound(BlockPos pos, BlockState state) {
+        this.playSound(this.getStepSound(), 1.0F, 1.0F);
+    }
+
+    public void listen(BlockPos eventPos, World eventWorld, LivingEntity eventEntity, int suspicion) {
+        if (!(this.emergeTicksLeft > 0) && this.world.getTime() - this.vibrationTimer >= 23) {
+            this.lasteventpos = eventPos;
+            this.lasteventworld = eventWorld;
+            this.lastevententity = eventEntity;
+            this.hasDetected = true;
+            this.vibrationTimer = this.world.getTime();
+            this.leaveTime = this.world.getTime() + 1200;
+            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_VIBRATION, SoundCategory.HOSTILE, 0.5F, world.random.nextFloat() * 0.2F + 0.8F);
+            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_SLIGHTLY_ANGRY, SoundCategory.HOSTILE, 1.0F, world.random.nextFloat() * 0.2F + 0.8F);
+            CreateVibration(this.world, this, lasteventpos);
+            if (eventEntity != null) {
+                addSuspicion(eventEntity, suspicion);
+            }
+        }
+    }
+
+    public void sculkSensorListen(BlockPos eventPos, BlockPos vibrationPos, World eventWorld, LivingEntity eventEntity, int suspicion) {
+        if (!(this.emergeTicksLeft > 0) && this.world.getTime() - this.vibrationTimer >= 23) {
+            this.lasteventpos = eventPos;
+            this.lastevententity = eventEntity;
+            this.lasteventworld = eventWorld;
+            this.hasDetected = true;
+            this.vibrationTimer = this.world.getTime();
+            this.leaveTime = this.world.getTime() + 1200;
+            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_VIBRATION, SoundCategory.HOSTILE, 0.5F, world.random.nextFloat() * 0.2F + 0.8F);
+            this.world.playSound(null, this.getBlockPos().up(2), RegisterSounds.ENTITY_WARDEN_SLIGHTLY_ANGRY, SoundCategory.HOSTILE, 1.0F, world.random.nextFloat() * 0.2F + 0.8F);
+            CreateVibration(this.world, this, vibrationPos);
+            if (eventEntity != null) {
+                addSuspicion(eventEntity, suspicion);
+            }
+        }
+    }
+
+    public void CreateVibration(World world, WardenEntity warden, BlockPos blockPos2) {
+        EntityPositionSource wardenPositionSource = new EntityPositionSource(this.getId()) {
+            @Override
+            public Optional<BlockPos> getPos(World world) {
+                return Optional.of(warden.getCameraBlockPos());
+            }
+            @Override
+            public PositionSourceType<?> getType() {
+                return PositionSourceType.ENTITY;
+            }
+        };
+        this.delay = this.distance = (int)Math.floor(Math.sqrt(warden.getCameraBlockPos().getSquaredDistance(blockPos2, false))) * 2;
+        ((ServerWorld)world).sendVibrationPacket(new Vibration(blockPos2, wardenPositionSource, this.delay));
+    }
+
+    public void followForTicks(LivingEntity entity, int ticks) {
+        this.followingEntity = entity.getId();
+        this.followTicksLeft = ticks;
+    }
+
+    public void addSuspicion(LivingEntity entity, int suspicion) {
+        if (!this.entityList.isEmpty()) {
+            if (this.entityList.contains(entity.getUuid().hashCode())) {
+                int slot = this.entityList.indexOf(entity.getUuid().hashCode());
+                this.susList.set(slot, this.susList.getInt(slot) + suspicion);
+                if (this.susList.getInt(slot)>=15 && this.getTrackingEntity()==null) {
+                    this.trackingEntity=entity.getUuidAsString();
+                    this.world.playSound(null, this.getBlockPos().up(), RegisterSounds.ENTITY_WARDEN_ROAR, SoundCategory.HOSTILE, 1F, 1F);
+                    this.roar();
+                }
+            } else {
+                this.entityList.add(entity.getUuid().hashCode());
+                this.susList.add(suspicion);
+            }
+        } else {
+            this.entityList.add(entity.getUuid().hashCode());
+            this.susList.add(suspicion);
+        }
+    }
+
+    public int getSuspicion(Entity entity) {
+        if (!this.entityList.isEmpty() && entity!=null) {
+            if (this.entityList.contains(entity.getUuid().hashCode())) {
+                int slot = this.entityList.indexOf(entity.getUuid().hashCode());
+                return this.susList.getInt(slot);
+            }
+        }
+        return 0;
+    }
+
+    public int getHighestSuspicionInt() {
+        int highest = 0;
+        if (!this.susList.isEmpty()) {
+            for (int i=0; i<this.susList.size(); i++) {
+                if (this.susList.getInt(i)>highest) {
+                    highest=this.susList.getInt(i);
                 }
             }
         }
-        if (this.mob.emergeTicksLeft>0) {
-            return false;
-        }
-        if (this.mob.getWorld().getTime()-this.mob.vibrationTimer>160 && sniffEntity!=null) {
-            exit = true;
-        }
-
-        int r = this.mob.getRoarTicksLeft1();
-        if (r > 0) {
-            exit = false;
-        }
-
-        return exit && UniformIntProvider.create(0,3).get(this.mob.getRandom())>0;
+        return highest;
     }
 
-    public void start() {
-        LivingEntity sniffEntity = null;
-        if (this.mob.mostSuspiciousAround()!=null) {
-            sniffEntity=this.mob.mostSuspiciousAround();
-        }
-        if (this.mob.getTrackingEntity()!=null) {
-            sniffEntity=this.mob.getTrackingEntity();
-        }
-        if (sniffEntity==null) {
-            LivingEntity closestPlayer = this.mob.getWorld().getClosestPlayer(this.mob, 16);
-            sniffEntity=closestPlayer;
-            if (closestPlayer==null) {
-                Box box = new Box(this.mob.getBlockPos().add(-16,-16,-16), this.mob.getBlockPos().add(16,16,16));
-                List<LivingEntity> entities = this.mob.getWorld().getNonSpectatingEntities(LivingEntity.class, box);
-                LivingEntity chosen = this.mob.getWorld().getClosestEntity(entities, TargetPredicate.DEFAULT, this.mob, this.mob.getX(), this.mob.getY(), this.mob.getZ());
-                if (chosen!=null) {
-                    sniffEntity=chosen;
+    public LivingEntity mostSuspiciousAround() {
+        int highest = 0;
+        LivingEntity most = null;
+        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
+        List<LivingEntity> entities = world.getNonSpectatingEntities(LivingEntity.class, box);
+        if (!entities.isEmpty()) {
+            for (LivingEntity target : entities) {
+                if (this.getBlockPos().getSquaredDistance(target.getBlockPos())<=16) {
+                    if (this.getSuspicion(target)>highest) {
+                        highest = this.getSuspicion(target);
+                        most = target;
+                    }
                 }
             }
         }
-
-        if (sniffEntity!=null) {
-            int extraSuspicion=0;
-            this.mob.sniffTicksLeft=34;
-            this.mob.sniffCooldown=134;
-            this.mob.sniffX=sniffEntity.getBlockPos().getX();
-            this.mob.sniffY=sniffEntity.getBlockPos().getY();
-            this.mob.sniffZ=sniffEntity.getBlockPos().getZ();
-            this.mob.vibrationTimer=this.mob.getWorld().getTime();
-            this.mob.getWorld().playSound(null, this.mob.getCameraBlockPos(), RegisterSounds.ENTITY_WARDEN_SNIFF, SoundCategory.HOSTILE, 1F, 1F);
-            if(this.mob.getBlockPos().getSquaredDistance(sniffEntity.getBlockPos(), true)<=8) {
-                extraSuspicion=extraSuspicion+1;
-            }
-            this.mob.addSuspicion(sniffEntity, UniformIntProvider.create(1,2).get(this.mob.getRandom()) + extraSuspicion);
-            this.mob.leaveTime=this.mob.getWorld().getTime()+1200;
+        return most;
+    }
+    public int mostSuspiciousAroundInt() {
+        int value=0;
+        if (mostSuspiciousAround()!=null) {
+            value=this.getSuspicion(mostSuspiciousAround());
         }
+        return value;
+    }
+    public LivingEntity getTrackingEntity() {
+        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
+        List<LivingEntity> entities = this.world.getNonSpectatingEntities(LivingEntity.class, box);
+        if (!entities.isEmpty()) {
+            for (LivingEntity target : entities) {
+                if (Objects.equals(this.trackingEntity, target.getUuidAsString())) {
+                    return target;
+                }
+            }
+        }
+        return null;
+    }
+    public boolean canFollow(Entity entity, boolean mustBeTracking) {
+        Box box = new Box(this.getBlockPos().add(-16,-16,-16), this.getBlockPos().add(16,16,16));
+        List<Entity> entities = world.getNonSpectatingEntities(Entity.class, box);
+        if (!entities.isEmpty() && entities.contains(entity)) {
+            if (mustBeTracking) {
+                if (entity == this.getTrackingEntity()) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+    public void writeCustomDataToNbt(NbtCompound nbt) {
+        super.writeCustomDataToNbt(nbt);
+        nbt.putLong("vibrationTimer", this.vibrationTimer);
+        nbt.putLong("leaveTime", this.leaveTime);
+        nbt.putInt("emergeTicksLeft", this.emergeTicksLeft);
+        nbt.putBoolean("hasEmerged", this.hasEmerged);
+        nbt.putIntArray("entityList", this.entityList);
+        nbt.putIntArray("susList", this.susList);
+        nbt.putString("trackingEntity", this.trackingEntity);
+        nbt.putInt("followTicksLeft", this.followTicksLeft);
+        nbt.putInt("followingEntity", this.followingEntity);
+        nbt.putInt("sniffTicksLeft", this.sniffTicksLeft);
+        nbt.putInt("sniffCooldown", this.sniffCooldown);
+        nbt.putInt("sniffX", this.sniffX);
+        nbt.putInt("sniffY", this.sniffY);
+        nbt.putInt("sniffZ", this.sniffZ);
+    }
+    public void readCustomDataFromNbt(NbtCompound nbt) {
+        super.readCustomDataFromNbt(nbt);
+        this.vibrationTimer = nbt.getLong("vibrationTimer");
+        this.leaveTime = nbt.getLong("leaveTime");
+        this.emergeTicksLeft = nbt.getInt("emergeTicksLeft");
+        this.hasEmerged = nbt.getBoolean("hasEmerged");
+        this.entityList = IntArrayList.wrap(nbt.getIntArray("entityList"));
+        this.susList = IntArrayList.wrap(nbt.getIntArray("susList"));
+        this.trackingEntity = nbt.getString("trackingEntity");
+        this.followTicksLeft = nbt.getInt("followTicksLeft");
+        this.followingEntity = nbt.getInt("followingEntity");
+        this.sniffTicksLeft = nbt.getInt("sniffTicksLeft");
+        this.sniffCooldown = nbt.getInt("sniffCooldown");
+        this.sniffX = nbt.getInt("sniffX");
+        this.sniffY = nbt.getInt("sniffY");
+        this.sniffZ = nbt.getInt("sniffZ");
     }
 
-    public void stop() {
+    public int eventSuspicionValue(GameEvent event, LivingEntity livingEntity) {
+        int total=1;
+        EntityType entity=livingEntity.getType();
+        if (entity==EntityType.PLAYER) {
+            total=total+2;
+        }
+        if (entity==EntityType.IRON_GOLEM) { //They're loud, you know?
+            total=total+1;
+        }
+        if (entity==EntityType.VILLAGER) { //It's similar to a player, you know?
+            total=total+1;
+        }
+        if (entity==EntityType.WITHER) { //It's loud, you know?
+            total=total+1;
+        }
+        if(this.getBlockPos().getSquaredDistance(livingEntity.getBlockPos(), true)<=8) {
+            total=total+1;
+        }
+        return total;
+    }
+    public int overallAnger() {
+        int anger=0;
+        for (int i=0; i<this.susList.size(); i++) {
+            anger=anger+this.susList.getInt(i);
+        }
+        return MathHelper.clamp(anger,0,25);
     }
 }

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/WardenGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/WardenGoal.java
@@ -41,17 +41,18 @@ public class WardenGoal extends Goal {
                        double distancey = Math.pow(this.mob.getBlockY() - lasteventpos.getY(), 2);
                        double distancez = Math.pow(this.mob.getBlockZ() - lasteventpos.getZ(), 2);
                        if (Math.sqrt(distancex + distancey + distancez) < 25) {
-                           if(this.mob.lastevententity!=null && this.mob.getSuspicion(this.mob.lastevententity)>=this.mob.getSuspicion(this.mob.navigationEntity) || this.mob.navigationEntity==null) {
-                               if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity!=this.mob.getTrackingEntity()) {
-                                   return false;
-                               } else if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity==this.mob.getTrackingEntity()) {
+                               exit = true;
+                               if (this.mob.getSuspicion(this.mob.lastevententity)>=this.mob.getSuspicion(this.mob.navigationEntity)) {
                                    this.mob.navigationEntity = this.mob.lastevententity;
-                                   return true;
+                                   exit=true;
                                }
-                               this.mob.navigationEntity = this.mob.lastevententity;
-                               return true;
-                           }
-                           exit = true;
+                               if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity!=this.mob.getTrackingEntity()) {
+                                   exit= false;
+                               }
+                               if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity==this.mob.getTrackingEntity()) {
+                                   this.mob.navigationEntity = this.mob.lastevententity;
+                                   exit=true;
+                               }
                        }
                    }
                }
@@ -74,18 +75,19 @@ public class WardenGoal extends Goal {
     }
 
     public boolean shouldContinue() {
-        if(this.mob.getSuspicion(this.mob.lastevententity)>=this.mob.getSuspicion(this.mob.navigationEntity) || this.mob.navigationEntity==null) {
-            if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity!=this.mob.getTrackingEntity()) {
-                return false;
-            } else if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity==this.mob.getTrackingEntity()) {
-                this.mob.navigationEntity = this.mob.lastevententity;
-                return true;
-            }
+        boolean exit=false;
+        if (this.mob.getSuspicion(this.mob.lastevententity)>=this.mob.getSuspicion(this.mob.navigationEntity)) {
             this.mob.navigationEntity = this.mob.lastevententity;
-            return true;
-        } else {
-            return this.mob.lastevententity == this.mob.navigationEntity;
+            exit=true;
         }
+        if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity!=this.mob.getTrackingEntity()) {
+            exit= false;
+        }
+        if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity==this.mob.getTrackingEntity()) {
+            this.mob.navigationEntity = this.mob.lastevententity;
+            exit=true;
+        }
+        return exit;
     }
 
     public void start() {
@@ -135,7 +137,6 @@ public class WardenGoal extends Goal {
                 this.mob.lasteventpos = null;
                 this.mob.lasteventworld = null;
             } else
-                this.mob.getNavigation().stop();
                 this.mob.getNavigation().startMovingTo(lasteventpos.getX(), lasteventpos.getY(), lasteventpos.getZ(), speed + (this.mob.overallAnger()*0.009));
 
         }

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/WardenGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/WardenGoal.java
@@ -43,14 +43,12 @@ public class WardenGoal extends Goal {
                        if (Math.sqrt(distancex + distancey + distancez) < 25) {
                                exit = true;
                                if (this.mob.getSuspicion(this.mob.lastevententity)>=this.mob.getSuspicion(this.mob.navigationEntity)) {
-                                   this.mob.navigationEntity = this.mob.lastevententity;
                                    exit=true;
                                }
                                if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity!=this.mob.getTrackingEntity()) {
                                    exit= false;
                                }
                                if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity==this.mob.getTrackingEntity()) {
-                                   this.mob.navigationEntity = this.mob.lastevententity;
                                    exit=true;
                                }
                        }
@@ -70,22 +68,33 @@ public class WardenGoal extends Goal {
            if (r > 0) {
                exit = false;
            }
-
+        int s = this.mob.sniffTicksLeft;
+        if (s > 0) {
+            exit = false;
+        }
+        if (exit && this.mob.getAttacker() == null) {
+            this.mob.navigationEntity = this.mob.lastevententity;
+        }
         return exit;
     }
 
     public boolean shouldContinue() {
         boolean exit=false;
         if (this.mob.getSuspicion(this.mob.lastevententity)>=this.mob.getSuspicion(this.mob.navigationEntity)) {
-            this.mob.navigationEntity = this.mob.lastevententity;
             exit=true;
         }
         if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity!=this.mob.getTrackingEntity()) {
             exit= false;
         }
         if (this.mob.getTrackingEntity()!=null && this.mob.lastevententity==this.mob.getTrackingEntity()) {
-            this.mob.navigationEntity = this.mob.lastevententity;
             exit=true;
+        }
+        if (exit) {
+            this.mob.navigationEntity = this.mob.lastevententity;
+        }
+        int s = this.mob.sniffTicksLeft;
+        if (s > 0) {
+            exit = false;
         }
         return exit;
     }

--- a/src/main/java/frozenblock/wild/mod/liukrastapi/WardenWanderGoal.java
+++ b/src/main/java/frozenblock/wild/mod/liukrastapi/WardenWanderGoal.java
@@ -1,0 +1,98 @@
+/*
+ * Decompiled with CFR 0.0.9 (FabricMC cc05e23f).
+ */
+package frozenblock.wild.mod.liukrastapi;
+
+import java.util.EnumSet;
+
+import frozenblock.wild.mod.entity.WardenEntity;
+import net.minecraft.entity.ai.NoPenaltyTargeting;
+import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
+
+public class WardenWanderGoal
+        extends Goal {
+    public static final int DEFAULT_CHANCE = 120;
+    protected final WardenEntity mob;
+    protected double targetX;
+    protected double targetY;
+    protected double targetZ;
+    protected final double speed;
+    protected int chance;
+    protected boolean ignoringChance;
+    private final boolean canDespawn;
+
+    public WardenWanderGoal(WardenEntity mob, double speed) {
+        this(mob, speed, 120);
+    }
+
+    public WardenWanderGoal(WardenEntity mob, double speed, int chance) {
+        this(mob, speed, chance, true);
+    }
+
+    public WardenWanderGoal(WardenEntity entity, double speed, int chance, boolean canDespawn) {
+        this.mob = entity;
+        this.speed = speed;
+        this.chance = chance;
+        this.canDespawn = canDespawn;
+        this.setControls(EnumSet.of(Goal.Control.MOVE));
+    }
+
+    @Override
+    public boolean canStart() {
+        Vec3d vec3d;
+        if (this.mob.getNavigation().isIdle() && this.mob.getWorld().getTime()-this.mob.vibrationTimer>400) {
+            if (this.mob.hasPassengers()) {
+                return false;
+            }
+            if (!this.ignoringChance) {
+                if (this.canDespawn && this.mob.getDespawnCounter() >= 100) {
+                    return false;
+                }
+                if (this.mob.getRandom().nextInt(WardenWanderGoal.toGoalTicks(this.chance)) != 0) {
+                    return false;
+                }
+            }
+            if ((vec3d = this.getWanderTarget()) == null) {
+                return false;
+            }
+            this.targetX = vec3d.x;
+            this.targetY = vec3d.y;
+            this.targetZ = vec3d.z;
+            this.ignoringChance = false;
+            return true;
+        }
+        return false;
+    }
+
+    @Nullable
+    protected Vec3d getWanderTarget() {
+        return NoPenaltyTargeting.find(this.mob, 10, 7);
+    }
+
+    @Override
+    public boolean shouldContinue() {
+        return !this.mob.getNavigation().isIdle() && !this.mob.hasPassengers() && this.mob.getWorld().getTime()-this.mob.vibrationTimer>400;
+    }
+
+    @Override
+    public void start() {
+        this.mob.getNavigation().startMovingTo(this.targetX, this.targetY, this.targetZ, this.speed);
+    }
+
+    @Override
+    public void stop() {
+        this.mob.getNavigation().stop();
+        super.stop();
+    }
+
+    public void ignoreChanceOnce() {
+        this.ignoringChance = true;
+    }
+
+    public void setChance(int chance) {
+        this.chance = chance;
+    }
+}
+

--- a/src/main/java/frozenblock/wild/mod/mixins/SimpleGameEventDispatcherMixin.java
+++ b/src/main/java/frozenblock/wild/mod/mixins/SimpleGameEventDispatcherMixin.java
@@ -115,11 +115,7 @@ public class SimpleGameEventDispatcherMixin{
                             wardie.getEntityWorld() == eventworld &&
                             MathAddon.distance(eventpos.getX(), eventpos.getY(), eventpos.getZ(), wardie.getX(), wardie.getY(), wardie.getZ()) <= 15
                     ) {
-                        if (event!=GameEvent.PROJECTILE_LAND) {
                             wardie.listen(eventpos, eventworld, evententity, wardie.eventSuspicionValue(event, evententity));
-                        } else {
-                            wardie.listen(eventpos, eventworld, null, 0);
-                        }
                     }
                 }
             }

--- a/src/main/java/frozenblock/wild/mod/registry/RegisterEntities.java
+++ b/src/main/java/frozenblock/wild/mod/registry/RegisterEntities.java
@@ -24,7 +24,7 @@ public class RegisterEntities {
 
     public static EntityType<MangroveBoatEntity> MANGROVE_BOAT;
     public static EntityType<ChestBoatEntity> CHEST_BOAT;
-    public static final EntityType<WardenEntity> WARDEN = Registry.register(Registry.ENTITY_TYPE, new Identifier(WildMod.MOD_ID, "warden"), FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, WardenEntity::new).dimensions(EntityDimensions.fixed(1.5f, 3.0f)).build());
+    public static final EntityType<WardenEntity> WARDEN = Registry.register(Registry.ENTITY_TYPE, new Identifier(WildMod.MOD_ID, "warden"), FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, WardenEntity::new).dimensions(EntityDimensions.fixed(1.5f, 2.95f)).build());
     public static final EntityType<FrogEntity> FROG = Registry.register(Registry.ENTITY_TYPE, new Identifier(WildMod.MOD_ID, "frog"), FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, FrogEntity::new).dimensions(EntityDimensions.fixed(0.75f, 0.75f)).build());
     public static final EntityType<TadpoleEntity> TADPOLE = Registry.register(Registry.ENTITY_TYPE, new Identifier(WildMod.MOD_ID, "tadpole"), FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TadpoleEntity::new).dimensions(EntityDimensions.fixed(0.5F, 0.3F)).build());
     public static final EntityType<FireflyEntity> FIREFLY = Registry.register(Registry.ENTITY_TYPE, new Identifier(WildMod.MOD_ID, "firefly"), FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, FireflyEntity::new).dimensions(EntityDimensions.fixed(0.5F, 0.3F)).build());


### PR DESCRIPTION
-Adds sniffing to the Warden
     -Chooses trackingEntity, most suspicious entity around, closest Player, and closest entity in that priority, and will sniff out its location if it's within 16 blocks.
     -By default sniffing adds 1 or 2 suspicion to an entity. If it's within 8 blocks of the Warden, one more suspicion point will get added.
-Warden can quit following a vibration and follow a new one if the new vibration is more suspicious
-Warden will always favor vibrations from trackingEntity over any other entity
-Warden will ignore all other entities if trackingEntity is nearby
-Handling for all lastEvent variables is more streamlined and less spammy
-Added a new class to replace WanderGoal to prevent the Warden from freezing and ignoring everything

Fixes #28 (or at least significantly minimizes it if that's not the case,) and should make the Warden feel smarter.